### PR TITLE
Fix html escaping problem

### DIFF
--- a/src/components/languageSwitcher.tsx
+++ b/src/components/languageSwitcher.tsx
@@ -8,7 +8,7 @@ import { languages } from "../i18n";
 
 export function LanguageSwitcher() {
     const { t } = useTranslation();
-    const helpTranslationText = `🖋&nbsp;${t("navbar.help_translating")}`;
+    const helpTranslationText = `🖋 ${t("navbar.help_translating")}`;
     return (
         <Navbar.Item touch={{ display: "hidden" }} desktop={{ only: true }} hoverable>
             <Navbar.Link className="has-text-white" key={i18n.resolvedLanguage}>


### PR DESCRIPTION
Fix html escaping problem before "navbar.help_translating"

![image](https://user-images.githubusercontent.com/600238/220980205-36ba8a71-b7b7-407f-b5c7-08d0bf899c79.png)
